### PR TITLE
Update arabsim.py with Pixel cast to Integer

### DIFF
--- a/arbalet/core/arbasim.py
+++ b/arbalet/core/arbasim.py
@@ -61,7 +61,7 @@ class Simulator(Thread):
                 for w in range(self.arbalet.width):
                     for h in range(self.arbalet.height):
                         pixel = model[h, w]
-                        self.display.fill(color.Color(pixel[0], pixel[1], pixel[2]),
+                        self.display.fill(color.Color(int(pixel[0]), int(pixel[1]), int(pixel[2])),
                                          Rect(w*self.cell_width,
                                          h*self.cell_height,
                                          self.cell_width,


### PR DESCRIPTION
Added integer cast for Pixel values as Pygame Color function in 1.9.1release gives a ValueError.